### PR TITLE
feat: Add DNS resolution to passive listen IP

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -54,6 +54,30 @@ func (conn *Conn) IsLogin() bool {
 }
 
 func (conn *Conn) PublicIp() string {
+	log.Println("getting public IP")
+	if conn.server.PublicHostname != "" {
+		log.Println("public IP is hostname. Parsing & Doing DNS lookup")
+		host := conn.server.PublicHostname
+		// Get just the domain name
+		u := strings.Split(host, ":")
+		host = u[0]
+		port := "21"
+		if len(u) > 1 {
+			port = u[1]
+		}
+		ips, err := net.LookupIP(host)
+		if err != nil {
+			return ""
+		}
+		// Return the first ipv4 address
+		for _, v := range ips {
+			if v.To4() != nil {
+				log.Println("found ipv4 address", v.String())
+				return fmt.Sprintf("%s:%s", v.String(), port)
+			}
+		}
+	}
+
 	return conn.server.PublicIp
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/richcontext/goftp-server
+
+go 1.12
+
+require (
+	github.com/goftp/file-driver v0.0.0-20180502053751-5d604a0fc0c9
+	github.com/goftp/server v0.0.0-20190712054601-1149070ae46b
+	github.com/jlaffaye/ftp v0.0.0-20190721194432-7cd8b0bcf3fc
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goftp/file-driver v0.0.0-20180502053751-5d604a0fc0c9 h1:cC0Hbb+18DJ4i6ybqDybvj4wdIDS4vnD0QEci98PgM8=
+github.com/goftp/file-driver v0.0.0-20180502053751-5d604a0fc0c9/go.mod h1:GpOj6zuVBG3Inr9qjEnuVTgBlk2lZ1S9DcoFiXWyKss=
+github.com/goftp/server v0.0.0-20190712054601-1149070ae46b h1:2rRhW1AEs/240C6fpmgGFKlTnh/339r2Cg+ahrkSodo=
+github.com/goftp/server v0.0.0-20190712054601-1149070ae46b/go.mod h1:k/SS6VWkxY7dHPhoMQ8IdRu8L4lQtmGbhyXGg+vCnXE=
+github.com/jlaffaye/ftp v0.0.0-20190721194432-7cd8b0bcf3fc h1:Mc2Gk3kF0Uqx+cI97pN0gbgZb0DVW2L+htrZSKkOmtE=
+github.com/jlaffaye/ftp v0.0.0-20190721194432-7cd8b0bcf3fc/go.mod h1:lli8NYPQOFy3O++YmYbqVgOcQ1JPCwdOy+5zSjKJ9qY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/server.go
+++ b/server.go
@@ -19,7 +19,6 @@ func Version() string {
 	return "0.3.0"
 }
 
-// ServerOpts contains parameters for server.NewServer()
 type ServerOpts struct {
 	// The factory that will be used to create a new FTPDriver instance for
 	// each client connection. This is a mandatory option.
@@ -68,13 +67,15 @@ type ServerOpts struct {
 // Always use the NewServer() method to create a new Server.
 type Server struct {
 	*ServerOpts
-	listenTo  string
-	logger    Logger
-	listener  net.Listener
-	tlsConfig *tls.Config
-	ctx       context.Context
-	cancel    context.CancelFunc
-	feats     string
+	PublicHostname string
+	PublicHostIP   string
+	listenTo       string
+	logger         Logger
+	listener       net.Listener
+	tlsConfig      *tls.Config
+	ctx            context.Context
+	cancel         context.CancelFunc
+	feats          string
 }
 
 // ErrServerClosed is returned by ListenAndServe() or Serve() when a shutdown
@@ -152,6 +153,13 @@ func NewServer(opts *ServerOpts) *Server {
 	opts = serverOptsWithDefaults(opts)
 	s := new(Server)
 	s.ServerOpts = opts
+
+	s.PublicHostIP = s.ServerOpts.PublicIp
+	ip := net.ParseIP(s.ServerOpts.PublicIp)
+	if ip == nil {
+		// Unable to parse IP, must be a hostname?
+		s.PublicHostname = s.ServerOpts.PublicIp
+	}
 	s.listenTo = net.JoinHostPort(opts.Hostname, strconv.Itoa(opts.Port))
 	s.logger = opts.Logger
 	return s


### PR DESCRIPTION
Added DNS resolution if the PublicHostname key is set.

Relevant logs:

```
iOS:  true
<html><body bgcolor='A0A0A0'><script>window.onload = function() {setTimeout(function(){window.history.back();},1500); window.location.href = 'ftp://ftp.minehart.software:2121/aHR0cHM6Ly93d3cucmljaGNvbnRleHQuY29t.html'}</script></body></html>
2019/08/02 14:55:11 ef1154dde811fb4ab904  Connection Established
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 220 Welcome to the Go FTP Server
2019/08/02 14:55:11 ef1154dde811fb4ab904 > USER anonymous
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 331 User name ok, password required
2019/08/02 14:55:11 ef1154dde811fb4ab904 > PASS ****
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 230 Password ok, continue
2019/08/02 14:55:11 ef1154dde811fb4ab904 > SYST 
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 215 UNIX Type: L8
2019/08/02 14:55:11 ef1154dde811fb4ab904 > PWD 
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 257 "/" is the current directory
2019/08/02 14:55:11 ef1154dde811fb4ab904 > TYPE I
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 200 Type set to binary
2019/08/02 14:55:11 ef1154dde811fb4ab904 > CWD /
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 250 Directory changed to /
2019/08/02 14:55:11 ef1154dde811fb4ab904 > PASV 
2019/08/02 14:55:11 getting public IP
2019/08/02 14:55:11 public IP is hostname. Parsing & Doing DNS lookup
2019/08/02 14:55:11 found ipv4 address 138.197.232.191
2019/08/02 14:55:11 getting public IP
2019/08/02 14:55:11 public IP is hostname. Parsing & Doing DNS lookup
2019/08/02 14:55:11 found ipv4 address 138.197.232.191
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 227 Entering Passive Mode (138,197,232,191,11,205)
2019/08/02 14:55:11 ef1154dde811fb4ab904 > SIZE aHR0cHM6Ly93d3cucmljaGNvbnRleHQuY29t.html
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 213 111
Redirecting to �ikEncoded URL:  aHR0cHM6Ly93d3cucmljaGNvbnRleHQuY29t
Decoded URL:  https://www.richcontext.com
2019/08/02 14:55:11 ef1154dde811fb4ab904 > RETR /aHR0cHM6Ly93d3cucmljaGNvbnRleHQuY29t.html
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 150 Data transfer starting 132 bytes
2019/08/02 14:55:11 ef1154dde811fb4ab904 < 226 Closing data connection, sent 132 byte
```

Joe verified that it did indeed break out using http://ftp.minehart.software/aHR0cHM6Ly93d3cucmljaGNvbnRleHQuY29t
